### PR TITLE
Added error callback to download prototype

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -279,6 +279,7 @@ Client.prototype.download = function(src, dest, callback) {
   var self = this;
 
   self.sftp(function(err,sftp){
+    if(!err){
     var sftp_readStream = sftp.createReadStream(src);
     sftp_readStream.on('error', function(err){
       callback(err);
@@ -291,6 +292,7 @@ Client.prototype.download = function(src, dest, callback) {
     .on('error', function(err){
       callback(err);
     });
+    }else{callback(err);}
   });
 };
 


### PR DESCRIPTION
Fixing this issue: https://github.com/spmjs/node-scp2/issues/18

If there is an error in the download function, it would break when trying to use "sftp". This fixes that.
